### PR TITLE
Include the Vulkan loader

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,8 +18,8 @@ on:
     branches:
       - 'master'
       - 'test*'
-    paths:
-      - 'COMMIT_ID'
+#    paths:
+#      - 'COMMIT_ID'
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,7 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         os:
           - ubuntu-16.04

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,13 +18,12 @@ on:
     branches:
       - 'master'
       - 'test*'
-#    paths:
-#      - 'COMMIT_ID'
+    paths:
+      - 'COMMIT_ID'
 
 jobs:
   build:
     strategy:
-      fail-fast: false
       matrix:
         os:
           - ubuntu-16.04

--- a/build.sh
+++ b/build.sh
@@ -226,22 +226,27 @@ esac
 
 ###### START EDIT ######
 
-# Amber has no install targets, so manually copy amber binary.
+# Amber has no install targets, so manually copy amber binary and the Vulkan loader.
 
 mkdir -p "${INSTALL_DIR}/bin"
+mkdir -p "${INSTALL_DIR}/lib"
 
 case "$(uname)" in
 "Linux")
   cp "${BUILD_DIR}/amber" "${INSTALL_DIR}/bin/"
+  cp "${BUILD_DIR}/third_party/vulkan-loader/loader/libvulkan."* "${INSTALL_DIR}/lib/"
   ;;
 
 "Darwin")
   cp "${BUILD_DIR}/amber" "${INSTALL_DIR}/bin/"
+  cp "${BUILD_DIR}/third_party/vulkan-loader/loader/libvulkan."* "${INSTALL_DIR}/lib/"
   ;;
 
 "MINGW"*)
   cp "${BUILD_DIR}/amber.exe" "${INSTALL_DIR}/bin/"
   cp "${BUILD_DIR}/amber.pdb" "${INSTALL_DIR}/bin/" || true
+  cp "${BUILD_DIR}/vulkan-1.dll" "${INSTALL_DIR}/lib/"
+  cp "${BUILD_DIR}/vulkan-1.pdb" "${INSTALL_DIR}/lib/" || true
   ;;
 
 *)
@@ -249,11 +254,6 @@ case "$(uname)" in
   exit 1
   ;;
 esac
-
-# Also, install the Vulkan loader; this allows Amber to be used on platforms that don't have a Vulkan loader/driver.
-pushd "${BUILD_DIR}/third_party/vulkan-loader"
-  cmake "-DCMAKE_INSTALL_PREFIX=../../../${INSTALL_DIR}" "-DBUILD_TYPE=${CMAKE_BUILD_TYPE}" -P cmake_install.cmake
-popd
 
 for f in "${INSTALL_DIR}/bin/"* "${INSTALL_DIR}/lib/"*; do
   echo "${BUILD_REPO_SHA}">"${f}.build-version"

--- a/build.sh
+++ b/build.sh
@@ -252,7 +252,7 @@ esac
 
 # Also, install the Vulkan loader; this allows Amber to be used on platforms that don't have a Vulkan loader/driver.
 pushd "${BUILD_DIR}/third_party/vulkan-loader"
-  cmake "-DCMAKE_INSTALL_PREFIX=${WORK}/${INSTALL_DIR}" "-DBUILD_TYPE=${CMAKE_BUILD_TYPE}" -P cmake_install.cmake
+  cmake "-DCMAKE_INSTALL_PREFIX=../../../${INSTALL_DIR}" "-DBUILD_TYPE=${CMAKE_BUILD_TYPE}" -P cmake_install.cmake
 popd
 
 for f in "${INSTALL_DIR}/bin/"* "${INSTALL_DIR}/lib/"*; do

--- a/build.sh
+++ b/build.sh
@@ -250,7 +250,12 @@ case "$(uname)" in
   ;;
 esac
 
-for f in "${INSTALL_DIR}/bin/"*; do
+# Also, install the Vulkan loader; this allows Amber to be used on platforms that don't have a Vulkan loader/driver.
+pushd "${BUILD_DIR}/third_party/vulkan-loader"
+  cmake "-DCMAKE_INSTALL_PREFIX=${WORK}/${INSTALL_DIR}" "-DBUILD_TYPE=${CMAKE_BUILD_TYPE}" -P cmake_install.cmake
+popd
+
+for f in "${INSTALL_DIR}/bin/"* "${INSTALL_DIR}/lib/"*; do
   echo "${BUILD_REPO_SHA}">"${f}.build-version"
   cp "${WORK}/COMMIT_ID" "${f}.version"
 done


### PR DESCRIPTION
This allows us to run Amber on platforms where there is no preinstalled Vulkan loader.